### PR TITLE
Fixes django error when using a version <1.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-Django >= 1.5, <1.8
+Django==1.8
 djangorestframework


### PR DESCRIPTION
When I downloaded and setup the project as the readme says, the default version of django installed(1.7.11) throws this exception: cannot import name DurationField.
Skillful google-fu led me to this piece of advice:  
The DurationField that is being imported by DRF was introduced in Django 1.8.
Hence, Installing Django 1.8 fixes the exception and allows the app to run.
